### PR TITLE
force module bigdecimal's version be '1.4.4'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'bigdecimal', '1.4.4'
 #gem 'jekyll-admin', group: :jekyll_plugins

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,2 @@
+bundler install
+bundle exec jekyll serve --livereload --host=0.0.0.0 --port=80


### PR DESCRIPTION
force module bigdecimal's version be '1.4.4', for not letting error on ruby 2.7+ on some platforms.

addition details can be found at https://github.com/ruby/bigdecimal